### PR TITLE
Update api_def_Angle.pbtxt

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -178,6 +178,8 @@ build:android_x86_64 --config=android
 build:android_x86_64 --cpu=x86_64
 build:android_x86_64 --fat_apk_cpu=x86_64
 
+build:verbs --define=with_verbs_support=true
+
 # Sets the default Apple platform to macOS.
 build:macos --apple_platform_type=macos
 

--- a/tensorflow/core/api_def/base_api/api_def_Angle.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_Angle.pbtxt
@@ -13,7 +13,7 @@ For example:
 
 ```
 # tensor 'input' is [-2.25 + 4.75j, 3.25 + 5.75j]
-tf.angle(input) ==> [2.0132, 1.056]
+tf.math.angle(input) ==> [2.0132, 1.056]
 ```
 
 @compatibility(numpy)


### PR DESCRIPTION
The Example code shown in the api_def_Angle.pbtxt still using 1.x version code which will throw:
`AttributeError: module 'tensorflow' has no attribute 'angle'` 
if used in 2.x. 
Hence updating the example code suitable to 2.x version. Please also refer attached [gist](https://colab.research.google.com/gist/SuryanarayanaY/c57df5a25572e7daebea235c633ce593/tf-math-angle.ipynb) for details.