### PR TITLE
update convert_image_dtype API

### DIFF
--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -2488,8 +2488,10 @@ def convert_image_dtype(image, dtype, saturate=False, name=None):
   """
   image = ops.convert_to_tensor(image, name='image')
   dtype = dtypes.as_dtype(dtype)
-  if dtype.is_complex or image.dtype.is_complex:
-    raise AttributeError('Both dtype and image.dtype must be either floating point or integer')
+  if not dtype.is_floating and not dtype.is_integer:
+    raise AttributeError('dtype must be either floating point or integer')
+  if not image.dtype.is_floating and not image.dtype.is_integer:
+    raise AttributeError('image dtype must be either floating point or integer')
   if dtype == image.dtype:
     return array_ops.identity(image, name=name)
 

--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -2488,8 +2488,8 @@ def convert_image_dtype(image, dtype, saturate=False, name=None):
   """
   image = ops.convert_to_tensor(image, name='image')
   dtype = dtypes.as_dtype(dtype)
-  if not dtype.is_floating and not dtype.is_integer:
-    raise AttributeError('dtype must be either floating point or integer')
+  if dtype.is_complex or image.dtype.is_complex:
+    raise AttributeError('Both dtype and image.dtype must be either floating point or integer')
   if dtype == image.dtype:
     return array_ops.identity(image, name=name)
 


### PR DESCRIPTION
At present the API tf.image.convert_image_dtype supports data types (for image and dtype) of uint8, uint16, uint32, uint64, int8, int16, int32, int64, float16, float32, float64, bfloat16 only.However passing complex data types like complex64,complex128 doesn't create error but outputs random(incorrect) results. Hence raising this PR so that this API validate inputs for any complex dtypes and raise the Attribute Error.Please also refer to the attached [gist](https://colab.research.google.com/gist/SuryanarayanaY/bae13f4fb3a35afaa6be958bb8b2f273/tf-image-convert_image_dtype-testcase-58699.ipynb).
Request for review and needful.
Thank you!